### PR TITLE
ADD replace for .git after repo url

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ function getRepo(baton) {
   if (!repo) {
     throw new Error(`${path.join(baton.dir, 'package.json')}: repository is not set.`)
   }
-  baton.repo = repo.replace(/https?:\/\/[^\/]+\//, '')
+  baton.repo = repo.replace(/https?:\/\/[^\/]+\//, '').replace('.git', '')
   return baton
 }
 


### PR DESCRIPTION
My git url in my package json looks like:

```
  "repository": {
    "type": "git",
    "url": "https://github.com/storybookjs/storybook.git"
  },
```

In order to get this to work, I had to take off `.git` or I'd get a 404 from GitHub.