### PR TITLE
Option to specify the repository URL when using the CLI

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -12,6 +12,7 @@ const cli = meow(
   Options
     --exclude, -e   Exclude contributors, glob.
     --limit, -l     Limit the number of contributors (default: 30).
+    --repo, -r     Repository URL (default: the URL in your package.json).
 
   Examples
     $ contributor-faces --exclude "*-bot"
@@ -19,7 +20,8 @@ const cli = meow(
   {
     alias: {
       e: 'exclude',
-      l: 'limit'
+      l: 'limit',
+      r: 'repository',
     }
   }
 )

--- a/index.js
+++ b/index.js
@@ -5,14 +5,18 @@ import replace from 'replace-in-file'
 import mm from 'micromatch'
 
 function getRepo(baton) {
-  const pkg = require(path.resolve(baton.dir, 'package.json'))
-  const repo = pkg.repository && (pkg.repository.url || pkg.repository)
+  var repo = baton.repo
+  if (!repo) {
+    const pkg = require(path.resolve(baton.dir, 'package.json'))
+    repo = pkg.repository && (pkg.repository.url || pkg.repository)
+  }
 
   if (!repo) {
     throw new Error(
       `${path.join(baton.dir, 'package.json')}: repository is not set.`
     )
   }
+
   baton.repo = repo.replace(/https?:\/\/[^\/]+\//, '').replace('.git', '')
   return baton
 }


### PR DESCRIPTION
Currently, running `contributor-faces` on a non-node project fails, because the project depends on `package.json` being available. With this change, I can use the CLI in non-node projects, by directly passing the repository's URL as a parameter to the CLI (we use it for github.com/okteto/okteto). 

What do you think?